### PR TITLE
Update library.json

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -66,7 +66,7 @@
         {
             "manufacturer": "IKEA",
             "model": "TRADFRI motion sensor (E1525/E1745)",
-            "battery_type": "CR2032"
+            "battery_type": "CR2032",
             "battery_quantity": 2
         },
         {

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -55,6 +55,11 @@
         },
         {
             "manufacturer": "IKEA",
+            "model": "TRADFRI ON/OFF switch (E1743)",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "IKEA",
             "model": "TRADFRI remote control (E1524/E1810)",
             "battery_type": "CR2032"
         },
@@ -62,6 +67,7 @@
             "manufacturer": "IKEA",
             "model": "TRADFRI motion sensor (E1525/E1745)",
             "battery_type": "CR2032"
+            "battery_quantity": 2
         },
         {
             "manufacturer": "IKEA",
@@ -116,6 +122,18 @@
             "battery_type": "CR2450"
         },
         {
+            "manufacturer": "Saswell",
+            "model": "Thermostatic radiator valve (SEA801-Zigbee/SEA802-Zigbee)",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Siterwell",
+            "model": "Radiator valve with thermostat (GS361A-H04)",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "Sonoff",
             "model": "Contact sensor (SNZB-04)",
             "battery_type": "CR2032"
@@ -128,7 +146,7 @@
         {
             "manufacturer": "Sonoff",
             "model": "Temperature and humidity sensor (SNZB-02)",
-            "battery_type": "CR2430"
+            "battery_type": "CR2450"
         },
         {
             "manufacturer": "Sure Petcare",


### PR DESCRIPTION
IKEA - TRADFRI motion sensor (E1525/E1745) - Edit to 2X CR2032

SONOFF - Temperature and humidity sensor (SNZB-02) - Edit to CR2450

IKEA - TRADFRI ON/OFF switch (E1743) - Added Configuration

Saswell - Thermostatic radiator valve (SEA801-Zigbee/SEA802-Zigbee) - Added Configuration

Siterwell - Radiator valve with thermostat (GS361A-H04) - Added Configuration