### PR TITLE
Added Airthings, Schlage, SmartThings and Zooz batteries

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -3,10 +3,22 @@
     "version": 1,
     "devices": [
         {
+            "manufacturer": "Airthings AS",
+            "model": "Wave Plus",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "Aldi",
             "model": "MEGOS switch and dimming light remote control (141L100RC)",
             "battery_type": "CR2450"
         },        
+        {
+            "manufacturer": "Allegion",
+            "model": "BE469ZP",
+            "battery_type": "AAA",
+            "battery_quantity": 4,
+        },
         {
             "manufacturer": "Develco",
             "model": "Smoke detector with siren (SMSZB-120)",
@@ -164,6 +176,16 @@
             "model": "Radiator valve with thermostat (GS361A-H04)",
             "battery_type": "AA",
             "battery_quantity": 2
+        },
+        {
+            "manufacturer": "SmartThings",
+            "model": "Multipurpose sensor (2016 model) (F-MLT-US-2)",
+            "battery_type": "CR2450",
+        },
+        {
+            "manufacturer": "SmartThings",
+            "model": "Multipurpose sensor (2018 model) (IM6001-MPP01)",
+            "battery_type": "CR2032",
         },
         {
             "manufacturer": "Sonoff",
@@ -325,6 +347,21 @@
         {
             "manufacturer": "Xiaomi",
             "model": "MiJia wireless switch (WXKG01LM)",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Zooz",
+            "model": "ZSE40 700",
+            "battery_type": "CR123A"
+        },
+        {
+            "manufacturer": "Zooz",
+            "model": "ZSE41",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Zooz",
+            "model": "ZSE42",
             "battery_type": "CR2032"
         },
         {

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -17,7 +17,7 @@
             "manufacturer": "Allegion",
             "model": "BE469ZP",
             "battery_type": "AAA",
-            "battery_quantity": 4,
+            "battery_quantity": 4
         },
         {
             "manufacturer": "Develco",
@@ -180,12 +180,12 @@
         {
             "manufacturer": "SmartThings",
             "model": "Multipurpose sensor (2016 model) (F-MLT-US-2)",
-            "battery_type": "CR2450",
+            "battery_type": "CR2450"
         },
         {
             "manufacturer": "SmartThings",
             "model": "Multipurpose sensor (2018 model) (IM6001-MPP01)",
-            "battery_type": "CR2032",
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "Sonoff",

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -179,13 +179,8 @@
         },
         {
             "manufacturer": "SmartThings",
-            "model": "Multipurpose sensor (2016 model) (F-MLT-US-2)",
-            "battery_type": "CR2450"
-        },
-        {
-            "manufacturer": "SmartThings",
             "model": "Multipurpose sensor (2018 model) (IM6001-MPP01)",
-            "battery_type": "CR2032"
+            "battery_type": "CR2450"
         },
         {
             "manufacturer": "Sonoff",


### PR DESCRIPTION
Added Airthings Wave+
Added Schlage BE469ZP
Added SmartThings Multipurpose sensor (2016 and 2018)
Added Zooz ZSE40, ZSE41 and ZSE42