### PR TITLE
Updated library.json to include addition of Kwikset HALO-01, Google Topaz-2.7, Google KR1 and Acurite Tower 06002RM

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -47,7 +47,7 @@
         },        {
             "manufacturer": "Google",
             "model": "Topaz-2.7",
-            "battery_type": "AA"
+            "battery_type": "AA",
             "battery_quantity": 3
         },
         {


### PR DESCRIPTION
Updated library to include the following:
* Kwikset HALO-01 smart Door locks (4 x AA)
* Google Topaz-2.7 Nest Protect wired model (3 x AA Energizer Ultimate Lithium “L91”)
* Google KR1 Nest Temperature Sensor (1 x CR2 Lithium)
* rtl_433 Acurite Tower (2 x AA)