### PR TITLE
Add devices from iNode, Oras/Hansa, Shelly, Tuya and Aqara/Xiaomi

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -259,6 +259,11 @@
             "battery_type": "CR2032"
         },
         {
+            "manufacturer": "iNode",
+            "model": "iNode Energy Meter",
+            "battery_type": "CR2032"
+        },
+        {
             "manufacturer": "Kwikset",
             "model": "HALO-01",
             "battery_type": "AA",
@@ -349,6 +354,11 @@
             "battery_quantity": 2
         },        
         {
+            "manufacturer": "Oras",
+            "model": "Electra Washbasin Faucet",
+            "battery_type": "2CR5"
+        },        
+        {
             "manufacturer": "ORVIBO",
             "model": "e70f96b3773a4c9283c6862dbafb6a99",
             "battery_type": "CR2032"
@@ -412,6 +422,22 @@
             "model": "Thermostatic radiator valve (SEA801-Zigbee/SEA802-Zigbee)",
             "battery_type": "AA",
             "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Shelly",
+            "model": "Shelly Door/Window 2",
+            "battery_type": "CR123A",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Shelly",
+            "model": "Shelly Flood",
+            "battery_type": "CR123A"
+        },
+        {
+            "manufacturer": "Shelly",
+            "model": "Shelly H&T",
+            "battery_type": "CR123A"
         },
         {
             "manufacturer": "Signify Netherlands B.V.",
@@ -571,6 +597,12 @@
         },
         {
             "manufacturer": "TuYa",
+            "model": "Temperature & humidity sensor with display (TS0201)",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "TuYa",
             "model": "TS0203",
             "battery_type": "CR2032"
         },    
@@ -666,6 +698,11 @@
         },               
         {
             "manufacturer": "Xiaomi",
+            "model": "Aqara T1 light intensity sensor (GZCGQ11LM)",
+            "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "Xiaomi",
             "model": "Aqara TVOC air quality monitor (VOCKQJK11LM)",
             "battery_type": "CR2450",
             "battery_quantity": 2
@@ -704,6 +741,11 @@
             "manufacturer": "Xiaomi",
             "model": "MCCGQ01LM",
             "battery_type": "CR1632"
+        },
+        {
+            "manufacturer": "Xiaomi",
+            "model": "XMWSDJ04MMC",
+            "battery_type": "CR2450"
         },
         {
             "manufacturer": "Xiaomi",


### PR DESCRIPTION
iNode Energy Meter, Electra Washbasin Faucet, Shelly Door/Window 2, Shelly Flood, Shelly H&T, Temperature & humidity sensor with display (TS0201), Aqara T1 light intensity sensor (GZCGQ11LM), XMWSDJ04MMC