### PR TITLE
Add Third Reality Smart Switch Gen 3 to library

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -639,6 +639,12 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "Third Reality",
+            "model": "Smart switch Gen3 (3RSS009Z)",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "TT Lock",
             "model": "SN511-180MS_PV53",
             "battery_type": "AA",


### PR DESCRIPTION
Adds battery type and quantity to library for [third reality smart switch gen 3](https://www.3reality.com/_files/ugd/6ff273_417a435cf4774c5a805407604657a9cd.pdf).