### PR TITLE
Add ecobee room sensor and smart sensor

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -48,6 +48,16 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "ecobee Inc.",
+            "model": "EBRSE4",
+            "battery_type": "CR2032",
+        },
+        {
+            "manufacturer": "ecobee Inc.",
+            "model": "EBERS41",
+            "battery_type": "CR2477",
+        },
+        {
             "manufacturer": "Eve Systems",
             "model": "Eve Door 20EBN9901",
             "battery_type": "ER14250"

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -50,12 +50,12 @@
         {
             "manufacturer": "ecobee Inc.",
             "model": "EBRSE4",
-            "battery_type": "CR2032",
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "ecobee Inc.",
             "model": "EBERS41",
-            "battery_type": "CR2477",
+            "battery_type": "CR2477"
         },
         {
             "manufacturer": "Eve Systems",


### PR DESCRIPTION
Adds the ecobee [smart temperature sensor](https://www.ecobee.com/en-us/accessories/smart-temperature-occupancy-sensor/#Features-and-Specs) and older [room temperature sensor](https://support.ecobee.com/s/articles/Room-Sensors-FAQs-Setup-Guide-and-Troubleshooting) battery types.