### PR TITLE
Add Sonoff SNZB-01 button

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -574,6 +574,11 @@
             "battery_type": "CR2450"
         },
         {
+            "manufacturer": "SONOFF",
+            "model": "Wireless button (SNZB-01)",
+            "battery_type": "CR2450"
+        },
+        {
             "manufacturer": "Sure Petcare",
             "model": "Cat flap",
             "battery_type": "AA",


### PR DESCRIPTION
Adds [Sonoff SNZB-01 wireless button](https://sonoff.tech/product/gateway-and-sensors/snzb-01/) battery type.