### PR TITLE
Add devices to library

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -3,6 +3,11 @@
     "version": 1,
     "devices": [
         {
+            "manufacturer": "Aeotec Ltd.",
+            "model": "ZWA003",
+            "battery_type": "LIR2450"
+        },
+        {
             "manufacturer": "Airthings AS",
             "model": "Wave Plus",
             "battery_type": "AAA",
@@ -68,6 +73,11 @@
             "manufacturer": "ecobee Inc.",
             "model": "EBERS41",
             "battery_type": "CR2477"
+        },
+        {
+            "manufacturer": "Ecolink",
+            "model": "DWZWAVE25",
+            "battery_type": "CR123A"
         },
         {
             "manufacturer": "Eve Systems",
@@ -595,6 +605,16 @@
         {
             "manufacturer": "SMaBiT (Bitron Video)",
             "model": "Compact magnetic contact sensor (AV2010/21A)",
+            "battery_type": "CR2"
+        },
+        {
+            "manufacturer": "SmartThings",
+            "model": "Button (IM6001-BTP01)",
+            "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "SmartThings",
+            "model": "Motion sensor (2018 model) (IM6001-MTP01)",
             "battery_type": "CR2"
         },
         {


### PR DESCRIPTION
- Aeotec ZWA003 Z-Wave 4-button remote
- Ecolink DWZWAVE25 Z-Wave contact sensor
- SmartThings IM6001-BTP01 Zigbee button
- SmartThings IM6001-MTP01 Zigbee motion sensor

Note that the Aeotec 4-button remote's battery is an LIR2450: it is both a standard type of removable/replaceable battery and a rechargeable battery. I opted to put the battery type instead of noting it as "Rechargeable" since that indicates a bespoke and usually non-removable/replaceable battery.