### PR TITLE
Add Aqara Door and Window Sensor P2

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -19,6 +19,11 @@
             "battery_type": "CR2450"
         },
         {
+            "manufacturer": "Aqara",
+            "model": "Aqara Door and Window Sensor P2"
+            "battery_type": "CR123A"
+        },
+        {
             "manufacturer": "Bosch",
             "model": "Radiator thermostat II (BTH-RA)",
             "battery_type": "AA",

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -20,7 +20,7 @@
         },
         {
             "manufacturer": "Aqara",
-            "model": "Aqara Door and Window Sensor P2"
+            "model": "Aqara Door and Window Sensor P2",
             "battery_type": "CR123A"
         },
         {


### PR DESCRIPTION
Added "Aqara Door and Window Sensor P2 by Aqara". This is the device info displayed in **Home Assistant  > Settings > Devices & services** when I added it to my instance of HA via the Matter (BETA) integration. This is my first ever pull request, so please forgive me if I did anything incorrectly. Thank you! 