### PR TITLE
Added device details (Xiaomi SRTS-A01, Sonoff TRVZB)

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -678,6 +678,17 @@
             "battery_type": "CR2450"
         },
         {
+	    "manufacturer": "SONOFF",
+	    "model": "TRVZB",
+	    "battery_type": "AA"
+	    "battery_quantity": 3
+	},
+	{
+	    "manufacturer": "SONOFF",
+	    "model": "Zigbee thermostatic radiator valve (TRVZB)",
+	    "battery_type": "AA",
+	    "battery_quantity": 3
+        {
             "manufacturer": "Sure Petcare",
             "model": "Cat flap",
             "battery_type": "AA",

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -680,7 +680,7 @@
         {
             "manufacturer": "SONOFF",
             "model": "TRVZB",
-            "battery_type": "AA"
+            "battery_type": "AA",
             "battery_quantity": 3
         },
         {

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -964,6 +964,12 @@
         },
         {
             "manufacturer": "Xiaomi",
+            "model": "Aqara Smart Radiator Thermostat E1 (SRTS-A01)",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Xiaomi",
             "model": "Aqara T1 light intensity sensor (GZCGQ11LM)",
             "battery_type": "CR2450"
         },
@@ -1053,6 +1059,12 @@
             "manufacturer": "Xiaomi",
             "model": "RTCGQ01LM",
             "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "Xiaomi",
+            "model": "SRTS-A01",
+            "battery_type": "AA",
+            "battery_quantity": 2
         },
         {
             "manufacturer": "Xiaomi",

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -561,7 +561,7 @@
             "model": "Doorbell 2",
             "battery_type": "Rechargeable"
         },
-	{
+        {
             "manufacturer": "Roborock",
             "model": "roborock.vacuum.a15",
             "battery_type": "Rechargeable"
@@ -678,16 +678,17 @@
             "battery_type": "CR2450"
         },
         {
-	    "manufacturer": "SONOFF",
-	    "model": "TRVZB",
-	    "battery_type": "AA"
-	    "battery_quantity": 3
-	},
-	{
-	    "manufacturer": "SONOFF",
-	    "model": "Zigbee thermostatic radiator valve (TRVZB)",
-	    "battery_type": "AA",
-	    "battery_quantity": 3
+            "manufacturer": "SONOFF",
+            "model": "TRVZB",
+            "battery_type": "AA"
+            "battery_quantity": 3
+        },
+        {
+            "manufacturer": "SONOFF",
+            "model": "Zigbee thermostatic radiator valve (TRVZB)",
+            "battery_type": "AA",
+            "battery_quantity": 3
+        },
         {
             "manufacturer": "Sure Petcare",
             "model": "Cat flap",


### PR DESCRIPTION
# Added

- Xiaomi Aqara Smart Radiator Thermostat E1 (SRTS-A01)
  - Alias: Xiaomi SRTS-A01
- SONOFF Zigbee thermostatic radiator valve (TRVZB)
  - Alias: SONOFF TRVZB