### PR TITLE
Additional devices

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -25,6 +25,11 @@
         },
         {
             "manufacturer": "Aeotec Ltd.",
+            "model": "ZWA008",
+            "battery_type": "ER14250"
+        },
+        {
+            "manufacturer": "Aeotec Ltd.",
             "model": "ZWA039",
             "battery_type": "CR2477"
         },

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -814,6 +814,11 @@
         },
         {
             "manufacturer": "Signify Netherlands B.V.",
+            "model": "Hue dimmer switch (RWL021)",
+            "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "Signify Netherlands B.V.",
             "model": "Hue dimmer switch (RWL022)",
             "battery_type": "CR2032"
         },

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -3,6 +3,17 @@
     "version": 1,
     "devices": [
         {
+            "manufacturer": "AEON Labs",
+            "model": "ZW100",
+            "battery_type": "CR123A",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "AEON Labs",
+            "model": "ZW112",
+            "battery_type": "Rechargeable"
+        },
+        {
             "manufacturer": "Aeotec Ltd.",
             "model": "ZWA003",
             "battery_type": "LIR2450"
@@ -56,6 +67,12 @@
             "model": "BE469ZP",
             "battery_type": "AAA",
             "battery_quantity": 4
+        },
+        {
+            "manufacturer": "Danfoss",
+            "model": "010101",
+            "battery_type": "AA",
+            "battery_quantity": 2
         },
         {
             "manufacturer": "Custom devices (DiY)",
@@ -238,6 +255,12 @@
             "battery_quantity": 4
         },
         {
+            "manufacturer": "Eurotronics",
+            "model": "Spirit",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "Fantem",
             "model": "4 in 1 multi sensor (ZB003-X)",
             "battery_type": "CR123A",
@@ -245,8 +268,23 @@
         },
         {
             "manufacturer": "Fibargroup",
+            "model": "FGMS001",
+            "battery_type": "CR123A"
+        },
+        {
+            "manufacturer": "Fibargroup",
             "model": "FGSD002",
             "battery_type": "CR123A"
+        },
+        {
+            "manufacturer": "Fibargroup",
+            "model": "FGDW002",
+            "battery_type": "ER14250"
+        },
+        {
+            "manufacturer": "Fibargroup",
+            "model": "FGK101",
+            "battery_type": "ER14250"
         },
         {
             "manufacturer": "frient",
@@ -567,6 +605,12 @@
         },
         {
             "manufacturer": "Netatmo",
+            "model": "Smart Anemometer",
+            "battery_type": "AA",
+            "battery_quantity": 4
+        },
+        {
+            "manufacturer": "Netatmo",
             "model": "Smart Thermostat",
             "battery_type": "AAA",
             "battery_quantity": 3
@@ -580,6 +624,12 @@
         {
             "manufacturer": "Netatmo",
             "model": "Smart Outdoor Module",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Netatmo",
+            "model": "Smart Rain Gauge",
             "battery_type": "AAA",
             "battery_quantity": 2
         },
@@ -736,6 +786,18 @@
         {
             "manufacturer": "Signify Netherlands B.V.",
             "model": "Hue motion sensor (SML001)",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Signify Netherlands B.V.",
+            "model": "Hue motion sensor (SML003)",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Signify Netherlands B.V.",
+            "model": "SML003",
             "battery_type": "AAA",
             "battery_quantity": 2
         },


### PR DESCRIPTION
- Hue motion sensor (SML003) from Philips (via Hue bridge and ZHA)
- Door/window sensors from Fibaro (via Z-Wave)
- Motion and Door/window sensors from Aeotec/AEON (via Z-Wave)
- TRVs from Eurotronics (Spirit) and Danfoss (via Z-Wave)
- Smart Anemometer and Rain Gauge from Netatmo
- Additional manufacturer/model combination for the Hue dimmer switch RWL021
