### PR TITLE
Added CentraLite, FirstAlert, IKEA and HAB Devices

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -531,6 +531,11 @@
         },
         {
             "manufacturer": "IKEA",
+            "model": "TRADFRI open/close remote (E1766)",
+            "battery_type": "CR2032"
+        },	    
+        {
+            "manufacturer": "IKEA",
             "model": "TRADFRI shortcut button (E1812)",
             "battery_type": "CR2032"
         },

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -74,16 +74,16 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "BRK Brands, Inc.",
+            "model": "ZCOMBO",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "Allegion",
             "model": "BE469ZP",
             "battery_type": "AAA",
             "battery_quantity": 4
-        },
-        {
-            "manufacturer": "Danfoss",
-            "model": "010101",
-            "battery_type": "AA",
-            "battery_quantity": 2
         },
         {
             "manufacturer": "CentraLite",
@@ -91,9 +91,25 @@
             "battery_type": "CR2"
         },
         {
+            "manufacturer": "CentraLite",
+            "model": "3320-L",
+            "battery_type": "CR2"
+        },
+        {
+            "manufacturer": "CentraLite",
+            "model": "3326-L",
+            "battery_type": "CR2"
+        },
+        {
             "manufacturer": "Custom devices (DiY)",
             "model": "Xiaomi temperature & humidity sensor with custom firmware (LYWSD03MMC)",
             "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Danfoss",
+            "model": "010101",
+            "battery_type": "AA",
+            "battery_quantity": 2
         },
         {
             "manufacturer": "Danfoss",
@@ -154,6 +170,12 @@
             "manufacturer": "Eve Systems",
             "model": "Eve Door 20EBN9901",
             "battery_type": "ER14250"
+        },
+        {
+            "manufacturer": "Everspring",
+            "model": "ST812",
+            "battery_type": "AA",
+            "battery_quantity": 2
         },
         {
             "manufacturer": "eWeLink",
@@ -378,6 +400,12 @@
             "battery_type": "ER14250"
         },
         {
+            "manufacturer": "First Alert (BRK Brands Inc)",
+            "model": "ZCOMBO",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "frient",
             "model": "MOSZB-140",
             "battery_type": "AA",
@@ -413,6 +441,11 @@
             "manufacturer": "Govee",
             "model": "H5101/H5102/H5177",
             "battery_type": "AAA"
+        },
+        {
+            "manufacturer": "HAB Home Intelligence LLC",
+            "model": "iblinds V3",
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "HANK Electronics Ltd.",
@@ -498,12 +531,17 @@
         },
         {
             "manufacturer": "IKEA",
-            "model": "TRADFRI open/close remote (E1766)",
+            "model": "TRADFRI shortcut button (E1812)",
             "battery_type": "CR2032"
         },
         {
-            "manufacturer": "IKEA",
-            "model": "TRADFRI shortcut button (E1812)",
+            "manufacturer": "IKEA of Sweden",
+            "model": "PRAKTLYSING cellular blind",
+            "battery_type": "Rechargeable"
+        },
+        {
+            "manufacturer": "IKEA of Sweden",
+            "model": "SYMFONISK Sound Controller",
             "battery_type": "CR2032"
         },
         {
@@ -539,6 +577,11 @@
             "battery_type": "CR2032"
         },
         {
+            "manufacturer": "IKEA of Sweden",
+            "model": "TREDANSEN block-out cellul blind",
+            "battery_type": "Rechargeable"
+        },
+        {
             "manufacturer": "iNode",
             "model": "iNode Energy Meter",
             "battery_type": "CR2032"
@@ -568,6 +611,18 @@
         {
             "manufacturer": "Kwikset",
             "model": "SMARTCODE_DEADBOLT_10T",
+            "battery_type": "AA",
+            "battery_quantity": 4
+        },
+        {
+            "manufacturer": "Kwikset",
+            "model": "910",
+            "battery_type": "AA",
+            "battery_quantity": 4
+        },
+        {
+            "manufacturer": "Kwikset",
+            "model": "912",
             "battery_type": "AA",
             "battery_quantity": 4
         },


### PR DESCRIPTION
Added CentraLite Motion and Door sensors
Added  BRK Brands, Inc. and FirstAlert ZCOMBO
Added IKEA of Sweden TREDANSEN block-out cellul blind roller blind 
Added HAB Home Intelligence LLC iblinds V3 roller blinds retrofit kit
Added Quikset door locks