### PR TITLE
Corrected battery type for Zooz ZEN34

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -1640,7 +1640,7 @@
         {
             "manufacturer": "Zooz",
             "model": "ZEN34",
-            "battery_type": "AAA",
+            "battery_type": "CR2032",
             "battery_quantity": 2
         },
         {


### PR DESCRIPTION
Fix battery type for Zooz ZEN34, from AAA to CR2032