### PR TITLE
removed CentraLite 3210-L as it has no battery, it was added by mistake

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -105,11 +105,6 @@
         },
         {
             "manufacturer": "CentraLite",
-            "model": "3210-L",
-            "battery_type": "CR2"
-        },
-        {
-            "manufacturer": "CentraLite",
             "model": "3315-S",
             "battery_type": "CR2"
         },


### PR DESCRIPTION
I removed the CentraLite device that I had added by mistake, this device has no battery