### PR TITLE
Update Netatmo Smart Indoor Module battery quantity from 2 to 4

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -907,7 +907,7 @@
             "manufacturer": "Netatmo",
             "model": "Smart Indoor Module",
             "battery_type": "AAA",
-            "battery_quantity": 2
+            "battery_quantity": 4
         },
         {
             "manufacturer": "Netatmo",


### PR DESCRIPTION
The Netatmo "Smart Indoor Module" had the battery quantity set to 2 when it should be 4 (https://www.netatmo.com/additional-smart-indoor-module/specifications), I think it's the same physical device (or a newer version) as the "Additional Indoor Module" that's defined a few lines above this one.