### PR TITLE
Fix Typo in Smartthings

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -1481,7 +1481,7 @@
             "battery_type": "CR2"
         },
         {
-            "manufacturer": "Smartthing",
+            "manufacturer": "Smartthings",
             "model": "STS-WTR-250",
             "battery_type": "CR2"
         },


### PR DESCRIPTION
Smartthings sensor submitted with name set to smartthing without the S