### PR TITLE
library.json: Add Xiaomi MJYD02YL

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2624,6 +2624,12 @@
         },
         {
             "manufacturer": "Xiaomi",
+            "model": "ble MJYD02YL",
+            "battery_type": "AAA",
+            "battery_quantity": 3
+        },
+        {
+            "manufacturer": "Xiaomi",
             "model": "ble MJYD02YL-A",
             "battery_type": "AAA",
             "battery_quantity": 3

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2625,7 +2625,7 @@
         {
             "manufacturer": "Xiaomi",
             "model": "ble MJYD02YL",
-            "battery_type": "AAA",
+            "battery_type": "AA",
             "battery_quantity": 3
         },
         {


### PR DESCRIPTION
My Xiaomi nightlights are not detected because they advertise themselves as MJYD02YL (instead of MJYD02YL-A). They look exactly like the MJYD02YL-A ones, maybe it's a different revision.