### PR TITLE
library.json: Fix MAX! Window Sensor

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -712,7 +712,7 @@
         {
             "manufacturer": "eQ-3",
             "model": "MAX! Window Sensor",
-            "battery_type": "AA",
+            "battery_type": "AAA",
             "battery_quantity": 2
         },
         {


### PR DESCRIPTION
MAX! Window Sensors take 2 AAA batteries (not AA), see https://www.eq-3.de/Downloads/eq3/downloads_produktkatalog/max/bda_portal/BC-SC-Rd-WM-2_UM_EN.pdf