### PR TITLE
library.json: add Xiaomi MUE4094RT

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2630,6 +2630,12 @@
         },
         {
             "manufacturer": "Xiaomi",
+            "model": "ble MUE4094RT",
+            "battery_type": "AA",
+            "battery_quantity": 3
+        },
+        {
+            "manufacturer": "Xiaomi",
             "model": "ble RTCGQ02LM",
             "battery_type": "CR2450"
         },


### PR DESCRIPTION
In Home Assistant, they show up as "MUE4094RT", not as "ble MUE4094RT". However, in library.json, all Xiaomi ble night lights are prefixed by "ble". Is that necessary for Battery Notes to work or some sort of artifact?