### PR TITLE
library.json: fix MJYD02YL-A

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2625,7 +2625,7 @@
         {
             "manufacturer": "Xiaomi",
             "model": "ble MJYD02YL-A",
-            "battery_type": "AAA",
+            "battery_type": "AA",
             "battery_quantity": 3
         },
         {


### PR DESCRIPTION
MJYD02YL-A uses AA type of batteries (not AAA)