### PR TITLE
Change Airthings Wave Plus and Allegion BE469ZP to AA, not AAA

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -194,7 +194,7 @@
         {
             "manufacturer": "Airthings AS",
             "model": "Wave Plus",
-            "battery_type": "AAA",
+            "battery_type": "AA",
             "battery_quantity": 2
         },
         {
@@ -217,7 +217,7 @@
         {
             "manufacturer": "Allegion",
             "model": "BE469ZP",
-            "battery_type": "AAA",
+            "battery_type": "AA",
             "battery_quantity": 4
         },
         {

--- a/library.md
+++ b/library.md
@@ -39,11 +39,11 @@ This file is auto generated, do not modify
 |Aeotec Ltd.                                     |ZWA019                                                                |LS14250             |
 |Aeotec Ltd.                                     |ZWA039                                                                |CR2477              |
 |Airthings                                       |View Radon                                                            |6x AA               |
-|Airthings AS                                    |Wave Plus                                                             |2x AA               |
+|Airthings AS                                    |Wave Plus                                                             |2x AAA              |
 |Aldi                                            |MEGOS switch and dimming light remote control (141L100RC)             |CR2450              |
 |Allegion                                        |BE468ZP                                                               |4x AA               |
 |Allegion                                        |BE469                                                                 |4x AA               |
-|Allegion                                        |BE469ZP                                                               |4x AA               |
+|Allegion                                        |BE469ZP                                                               |4x AAA              |
 |American Power Conversion                       |Back-UPS ES 600M1                                                     |Rechargable         |
 |American Power Conversion                       |Back-UPS XS 1500M                                                     |Rechargable         |
 |APC                                             |Back-UPS XS 1500M                                                     |Rechargeable        |

--- a/library.md
+++ b/library.md
@@ -39,11 +39,11 @@ This file is auto generated, do not modify
 |Aeotec Ltd.                                     |ZWA019                                                                |LS14250             |
 |Aeotec Ltd.                                     |ZWA039                                                                |CR2477              |
 |Airthings                                       |View Radon                                                            |6x AA               |
-|Airthings AS                                    |Wave Plus                                                             |2x AAA              |
+|Airthings AS                                    |Wave Plus                                                             |2x AA               |
 |Aldi                                            |MEGOS switch and dimming light remote control (141L100RC)             |CR2450              |
 |Allegion                                        |BE468ZP                                                               |4x AA               |
 |Allegion                                        |BE469                                                                 |4x AA               |
-|Allegion                                        |BE469ZP                                                               |4x AAA              |
+|Allegion                                        |BE469ZP                                                               |4x AA               |
 |American Power Conversion                       |Back-UPS ES 600M1                                                     |Rechargable         |
 |American Power Conversion                       |Back-UPS XS 1500M                                                     |Rechargable         |
 |APC                                             |Back-UPS XS 1500M                                                     |Rechargeable        |


### PR DESCRIPTION
Looks like #55 listed the Airthings Wave Plus and Allegion BE469ZP as using AAA batteries when they really use AAs. (The quantities were right, though!)

For the Airthings, see the "Additional specifications" section [on this page](https://www.airthings.com/en/wave-plus).

For the Allegion/Schlage, see the "Specifications" section [on this page](https://www.schlage.com/en/home/products/BE469ZPCAMFFF.html).

Thanks for this project! Excited to start using it.