### PR TITLE
chore: Add missing LUMI devices

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -1454,12 +1454,22 @@
         },
         {
             "manufacturer": "LUMI",
+            "model": "lumi.sensor_cube",
+            "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "LUMI",
             "model": "lumi.sensor_cube.aqgl01",
             "battery_type": "CR2450"
         },
         {
             "manufacturer": "LUMI",
             "model": "lumi.sensor_h1",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "LUMI",
+            "model": "lumi.sensor_ht",
             "battery_type": "CR2032"
         },
         {
@@ -1489,12 +1499,22 @@
         },
         {
             "manufacturer": "LUMI",
+            "model": "lumi.sensor_switch.aq2",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "LUMI",
             "model": "lumi.sensor_switch.aq3",
             "battery_type": "CR2032"
         },
         {
             "manufacturer": "LUMI",
             "model": "lumi.sensor_wleak.aq1",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "LUMI",
+            "model": "lumi.sensor_86sw1",
             "battery_type": "CR2032"
         },
         {


### PR DESCRIPTION
This PR adds some LUMI/Aquara devices I have at home that are managed by ZHA but not discovered automagically by Battery-Notes
