### PR TITLE
Add Aqara, Sengled, Airthings, Govee, BlueMaestro devices to library

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -286,6 +286,12 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "Airthings AS",
+            "model": "Wave Radon",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "Alarm.com",
             "model": "n/a",
             "battery_type": "CR123A"
@@ -346,6 +352,11 @@
         },
         {
             "manufacturer": "Aqara",
+            "model": "Door and window sensor (MCCGQ11LM)",
+            "battery_type": "CR1632"
+        },
+        {
+            "manufacturer": "Aqara",
             "model": "Smart smoke detector (JY-GZ-01AQ)",
             "battery_type": "CR17450"
         },
@@ -354,6 +365,26 @@
             "model": "SRTS-A01",
             "battery_type": "AA",
             "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Aqara",
+            "model": "Temperature and humidity sensor (WSDCGQ11LM)",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Aqara",
+            "model": "Vibration sensor (DJT11LM)",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Aqara",
+            "model": "Water leak sensor (SJCGQ11LM)",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Aqara",
+            "model": "Wireless mini switch (WXKG11LM)",
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "Aqara",
@@ -509,6 +540,11 @@
             "model": "FRITZ!DECT 440",
             "battery_type": "AAA",
             "battery_quantity": 2
+        },
+        {
+            "manufacturer": "BlueMaestro",
+            "model": "Tempo Disc THD",
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "Bosch",
@@ -1205,6 +1241,11 @@
             "model": "H5072/H5075",
             "battery_type": "AAA",
             "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Govee",
+            "model": "H5074",
+            "battery_type": "CR2477"
         },
         {
             "manufacturer": "Govee",
@@ -2261,6 +2302,11 @@
         {
             "manufacturer": "Sengled",
             "model": "E1D-G73",
+            "battery_type": "CR1632"
+        },
+        {
+            "manufacturer": "Sengled",
+            "model": "Smart window and door sensor (E1D-G73WNA)",
             "battery_type": "CR1632"
         },
         {


### PR DESCRIPTION
Add various Aqara sensors (Z2M variant), Sengled door sensors, Airthings Wave Radon, Govee H5074 temp sensors, BlueMaestro Tempo discs. 9 new devices added.