### PR TITLE
fix: correct hue dimmers battery type

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2338,12 +2338,12 @@
         {
             "manufacturer": "Philips",
             "model": "Hue dimmer switch (324131092621)",
-            "battery_type": "CR2450"
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "Philips",
             "model": "Hue dimmer switch (929002398602)",
-            "battery_type": "CR2450"
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "Philips",


### PR DESCRIPTION
Both of these devices use CR2032 instead of CR2450.