### PR TITLE
fix: revert philips 324131092621 battery to CR2450

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2423,7 +2423,7 @@
         {
             "manufacturer": "Philips",
             "model": "Hue dimmer switch (324131092621)",
-            "battery_type": "CR2032"
+            "battery_type": "CR2450"
         },
         {
             "manufacturer": "Philips",


### PR DESCRIPTION
Sanity checked myself and Philips 324131092621 was indeed using CR2450 all along, sorry for that change in #1068. Only Philips 929002398602 needed correction from CR2450 to CR2032