### PR TITLE
GH Linting Improvements

### DIFF
--- a/.github/workflows/json_validate.yml
+++ b/.github/workflows/json_validate.yml
@@ -4,10 +4,12 @@ on:
   workflow_dispatch:
   push:
     paths:
+    - 'custom_components/battery_notes/schema.json'
     - 'custom_components/battery_notes/data/**'
     - '.github/workflows/json*.yml'
   pull_request:
     paths:
+    - 'custom_components/battery_notes/schema.json'
     - 'custom_components/battery_notes/data/**'
     - '.github/workflows/json*.yml'
 

--- a/.github/workflows/json_validate.yml
+++ b/.github/workflows/json_validate.yml
@@ -5,11 +5,11 @@ on:
   push:
     paths:
     - 'custom_components/battery_notes/data/**'
-    - '.github/workflows/**'
+    - '.github/workflows/json*.yml'
   pull_request:
     paths:
     - 'custom_components/battery_notes/data/**'
-    - '.github/workflows/**'
+    - '.github/workflows/json*.yml'
 
 jobs:
   verify-json-validation:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,40 +2,60 @@ name: Lint
 
 on:
   push:
-    branches:
-      - "main"
     paths:
       - '**.py' # Run if pushed commits include a change to a Python (.py) file.
-      - '.github/workflows/*.yml' # Run if pushed commits include a change to a github actions workflow file.
+      - '.github/workflows/lint.yml' # Run if pushed commits include a change to a github actions workflow file.
       - 'requirements.txt' # Run if pushed commits include a change to the Python requirements.txt file.
+      - '.ruff.toml' # Run if ruff configuration file changes.
   pull_request:
-    branches:
-      - "main"
     paths:
       - '**.py' # Run if pushed commits include a change to a Python (.py) file.
-      - '.github/workflows/*.yml' # Run if pushed commits include a change to a github actions workflow file.
+      - '.github/workflows/lint.yml' # Run if pushed commits include a change to a github actions workflow file.
       - 'requirements.txt' # Run if pushed commits include a change to the Python requirements.txt file.
+      - '.ruff.toml' # Run if ruff configuration file changes.
   workflow_dispatch:
 
 jobs:
   build:
-    runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.12"
+          - "3.11"
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
 
-    - name: Install dependencies from requirements.txt
-      run: |
-        if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+      - name: Install uv and create venv
+        run: |
+          pip install -U pip uv
+          uv venv
 
-    - name: Analyse the code with ruff
-      run: |
-        python3 -m ruff check .
+      - name: Enable venv
+        run: |
+          source .venv/bin/activate
+          echo $PATH >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+
+      - name: Lint the code with ruff
+        run: |
+          ruff check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,4 +58,10 @@ jobs:
 
       - name: Lint the code with ruff
         run: |
-          ruff check .
+          ruff check $(git ls-files '*.py') --output-format sarif -o results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: ruff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
           zip battery_notes.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.1
         with:
           files: ${{ github.workspace }}/custom_components/battery_notes/battery_notes.zip

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,7 @@
 
 target-version = "py310"
 
+[lint]
 select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
@@ -25,7 +26,6 @@ select = [
     "UP",  # pyupgrade
     "W",  # pycodestyle
 ]
-
 ignore = [
     "D202",  # No blank lines allowed after function docstring
     "D203",  # 1 blank line required before class docstring

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-colorlog==6.8.2
-homeassistant==2023.11.0
-pip>=21.0,<24.1
-ruff==0.3.0
+colorlog>=6.8.2,<7.0
+homeassistant>=2023.11.0
+ruff>=0.3.2,<0.4


### PR DESCRIPTION
* JSON validation was being run when other actions were modified, no longer does
* Added python 3.12 to linting version matrix to watch for use of deprecated syntax and methods
* Remove branch filter from linting workflow (so it lints any forks and PRs)
* Use ruff command line flags to export results as SARIF file and upload to GitHub CodeQL
* Requirements.txt uses ">=X, <X" syntx to allow future minor+patch updates but not future major versions (except to homeassistant)
* Use [uv](https://github.com/astral-sh/uv) for installing requirements in linting action to reduce runtime