### PR TITLE
fix: SRT321 changed manufacturer

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2870,7 +2870,7 @@
             "battery_quantity": 2
         },
         {
-            "manufacturer": "Secure Meters",
+            "manufacturer": "Secure Meters (UK) Ltd.",
             "model": "SRT321",
             "battery_type": "AAA",
             "battery_quantity": 2

--- a/library.md
+++ b/library.md
@@ -533,7 +533,7 @@ Request new devices to be added to the library [here](https://github.com/andrew-
 |Schlage                                         |BE469NX                                                               |4× AA                     |
 |Schlage                                         |be499WB                                                               |4× AA                     |
 |Schneider Electric                              |Wiser radiator thermostat (WV704R0A0902)                              |2× AA                     |
-|Secure Meters                                   |SRT321                                                                |2× AAA                    |
+|Secure Meters (UK) Ltd.                         |SRT321                                                                |2× AAA                    |
 |Sengled                                         |E1D-G73                                                               |CR1632                    |
 |Sengled                                         |Smart window and door sensor (E1D-G73WNA)                             |CR1632                    |
 |SensorPush                                      |HTP.xw                                                                |CR2477                    |


### PR DESCRIPTION
My SRT321 do not appear under 'Secure Meters' manufacturer anymore,  but 'Secure Meters (UK) Ltd.' I do not know if you want to keep both, neither why this has changed in home assistant or zwave2mqtt. Probably an update in the later.