### PR TITLE
fix model name for WXKG02LM_rev2

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -4739,6 +4739,11 @@
         },
         {
             "manufacturer": "Xiaomi",
+            "model": "Wireless remote switch (double rocker), 2018 model (WXKG02LM_rev2)",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Xiaomi",
             "model": "Aqara E1 door & window contact sensor (MCCGQ14LM)",
             "battery_type": "CR1632"
         },

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -4739,7 +4739,7 @@
         },
         {
             "manufacturer": "Xiaomi",
-            "model": "Wireless remote switch (double rocker), 2018 model (WXKG02LM_rev2)",
+            "model": "Aqara double key wireless wall switch (2018 model) (WXKG02LM_rev2)",
             "battery_type": "CR2032"
         },
         {


### PR DESCRIPTION
Sorry, the model name was wrong. Z2M provides 2 different names to HA. I thought I had copy/pasted the one from HA but it actually was the one from Z2M.