### PR TITLE
Fixed Incorrectly Named Service Parameter

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -26,7 +26,7 @@ See how to use this service in the [community contributions](./community.md)
 
 | Parameter                | Optional | Description                                                                                                           |
 | ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `data.days`      | `no`    |  The number of days since a device last reported its battery level. |
+| `data.days_last_reported`      | `no`    |  The number of days since a device last reported its battery level. |
 
 ## battery_notes.check_battery_low
 


### PR DESCRIPTION
The `battery_notes.check_battery_last_reported` service had parameter `data.days`. This was incorrect and should have been `data.days_last_reported`. The service call is correct in all the community examples.