### PR TITLE
Plant Sensor SGS01 via TuyaBLE integration

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -4726,6 +4726,12 @@
         },
         {
             "manufacturer": "Tuya",
+            "model": "SGS01 (gvygg3m8)",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Tuya",
             "model": "R459",
             "battery_type": "AAA",
             "battery_quantity": 2


### PR DESCRIPTION
Support for this sensor has already been added, but TuyaBLE integration sets the model name differently, so it requires separate entry for such cases. This should close #1861 