### PR TITLE
Add Moes thermostat radiator valve variants

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2973,6 +2973,18 @@
         },
         {
             "manufacturer": "Moes",
+            "model": "Thermostat radiator valve (TV01-ZB)",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Moes",
+            "model": "Thermostat radiator valve (ZTRV-ZX-TV01-MS)",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
+            "manufacturer": "Moes",
             "model": "Universal smart IR remote control (UFO-R11)",
             "battery_type": "AAA",
             "battery_quantity": 2


### PR DESCRIPTION
* Thermostat radiator valve (TV01-ZB)
* Thermostat radiator valve (ZTRV-ZX-TV01-MS)

Apart from the model name they are identical to the already existing radiator valve. Tested and working on my local HA instance.

Thanks for the awesome component :)