### PR TITLE
Fix Ring batteries having additional quotes

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -4020,7 +4020,7 @@
         {
             "manufacturer": "Ring",
             "model": "Intercom",
-            "battery_type": "\"Rechargeable\""
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "Ring",
@@ -4031,7 +4031,7 @@
         {
             "manufacturer": "Ring",
             "model": "Peephole Cam",
-            "battery_type": "\"Rechargeable\""
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "Ring",

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -5144,7 +5144,7 @@
         {
             "manufacturer": "Tile",
             "model": "T1101",
-            "battery_type": "Cr2032"
+            "battery_type": "CR2032"
         },
         {
             "manufacturer": "Tile",

--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2674,12 +2674,12 @@
         {
             "manufacturer": "Ikea",
             "model": "FYRTUR roller blind, block-out (E1757)",
-            "battery_type": "BRAUNIT Battery pack (rechargeable)"
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "Ikea",
             "model": "KADRILJ roller blind (E1926)",
-            "battery_type": "BRAUNIT Battery pack (rechargeable)"
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "IKEA",
@@ -2787,12 +2787,12 @@
         {
             "manufacturer": "IKEA of Sweden",
             "model": "FYRTUR block-out roller blind",
-            "battery_type": "BRAUNIT Battery pack"
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "IKEA of Sweden",
             "model": "KADRILJ roller blind",
-            "battery_type": "BRAUNIT Battery pack"
+            "battery_type": "Rechargeable"
         },
         {
             "manufacturer": "IKEA of Sweden",


### PR DESCRIPTION
The additional quotes are unnecessary here, and were breaking some templates I was creating with HA 😁 

Also, some IKEA batteries were incorrect and should have been "Rechargeable" (but not with extra quotes).