### PR TITLE
Bug: Incorrect Aqara water leak sensor T1 model definition

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -899,8 +899,7 @@
         },
         {
             "manufacturer": "Aqara",
-            "model": "Water leak sensor T1",
-            "model_id": "SJCGQ12LM",
+            "model": "Water leak sensor T1 (SJCGQ12LM)",
             "battery_type": "CR2032"
         },
         {


### PR DESCRIPTION
This device was not correctly identified by Battery Notes because part of the `model` was set as the `model_id` instead. Compare with the non-TI water leak sensor that follows the same pattern.