### PR TITLE
chore: add alias for Ikea vallhorn

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2891,6 +2891,12 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "IKEA of Sweden",
+            "model": "VALLHORN Wireless Motion Sensor",
+            "battery_type": "AAA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "IKEA",
             "model": "Water leakage detection sensor (E2202)",
             "battery_type": "AAA"


### PR DESCRIPTION
Hey, 

it seems that my vallhorn wasn't correctly picked up because of slight differences in the name