### PR TITLE
Add Aqara water leak sensor

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -803,6 +803,11 @@
         },
         {
             "manufacturer": "Aqara",
+            "model": "AS010",
+            "battery_type": "CR2032"
+        },
+        {
+            "manufacturer": "Aqara",
             "model": "Cube (MFKZQ01LM)",
             "battery_type": "CR2450"
         },


### PR DESCRIPTION
Water leak sensor is already there but it was not recognized for me. Mine is added through Homekit and the model is shown as just AS010