### PR TITLE
Update library.json - corrected 3 Homematic entries

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -2434,29 +2434,25 @@
         },
         {
             "manufacturer": "eQ-3",
-            "model": "Homematic Funk-T\u00fcrschlossantrieb KeyMatic",
-            "model_id": "HM-Sec-Key",
+            "model": "HM-Sec-Key",
             "battery_type": "AA",
             "battery_quantity": 3
         },
         {
             "manufacturer": "eQ-3",
-            "model": "Homematic IP Bewegungsmelder",
-            "model_id": "HmIP-SMO-A",
+            "model": "HmIP-SMO-A",
             "battery_type": "AA",
             "battery_quantity": 2
         },
         {
             "manufacturer": "eQ-3",
-            "model": "Homematic IP Bewegungsmelder",
-            "model_id": "HmIP-SMO-A-2",
+            "model": "HmIP-SMO-A-2",
             "battery_type": "AA",
             "battery_quantity": 2
         },
         {
             "manufacturer": "eQ-3",
-            "model": "Homematic IP Temperatur- und Luftfeuchtigkeitssensor",
-            "model_id": "HmIP-STHO",
+            "model": "HmIP-STHO",
             "battery_type": "AA",
             "battery_quantity": 2
         },


### PR DESCRIPTION
Homematic / Homematic IP devices must provide their model name as model and not model-id