### PR TITLE
Fix VCZ1 battery type

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -6740,7 +6740,7 @@
         {
             "manufacturer": "Springs Window Fashions",
             "model": "VCZ1",
-            "battery_type": "CR2439"
+            "battery_type": "CR2430"
         },
         {
             "manufacturer": "Sure Petcare",


### PR DESCRIPTION
Battery type was incorrectly configured as "CR2439"