### PR TITLE
Revert "Device: _TZE200_3towulqd - TS0601"

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -392,7 +392,7 @@
         {
             "manufacturer": "_TZE200_3towulqd",
             "model": "TS0601",
-            "battery_type": "CR2045"
+            "battery_type": "CR2450"
         },
         {
             "manufacturer": "_TZE200_4eeyebrt",


### PR DESCRIPTION
Reverts andrew-codechimp/HA-Battery-Notes#3369

My bad, already existed and this introduced a typo in the battery model.