### PR TITLE
fix: naming issue in German repair issue description

### DIFF
--- a/custom_components/battery_notes/translations/de.json
+++ b/custom_components/battery_notes/translations/de.json
@@ -195,7 +195,7 @@
                 "step": {
                     "confirm": {
                         "title": "Fehlerhafter Eintrag in \"Battery Notes\"",
-                        "description": "Das zugehörige Gerät oder die Entität des Eintrags {name} in \"Battery Notes\" ist nicht mehr vorhanden, der Eintrag sollte gelöscht werden.\nWählen Sie **Absenden** um diesen Eintrag zu löschen."
+                        "description": "Das zugehörige Gerät oder die Entität des Eintrags {name} in \"Battery Notes\" ist nicht mehr vorhanden, der Eintrag sollte gelöscht werden.\nWählen Sie **OK** um diesen Eintrag zu löschen."
                     }
                 }
             }


### PR DESCRIPTION
This fixes a missmatch in the German description for a repair issue.

<img width="577" height="245" alt="Bildschirmfoto 2025-07-24 um 06 34 33" src="https://github.com/user-attachments/assets/90ee6a44-795e-4e90-aee5-554614fc6191" />
