### PR TITLE
Device: Eltako - A5-08-01

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -2457,6 +2457,11 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "Eltako",
+            "model": "A5-08-01",
+            "battery_type": "CR2032"
+        },
+        {
             "manufacturer": "Elro",
             "model": "CO alarm",
             "battery_type": "AA",


### PR DESCRIPTION
This pull request adds the device information for:
Manufacturer: Eltako
Model: A5-08-01
Battery: CR2032