### PR TITLE
Add SAF Tehnika Aranet4 battery specifications

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -7341,6 +7341,12 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "SAF Tehnika",
+            "model": "Aranet4",
+            "battery_type": "AA",
+            "battery_quantity": 2
+        },
+        {
             "manufacturer": "Samjin",
             "model": "button",
             "battery_type": "CR2450"


### PR DESCRIPTION
Aranet4 Home exists in the library however the earlier Aranet4 sensors do not have the word "Home" in the model name