### PR TITLE
fix: use dot instead of colon for microsecond separator of last_replaced in strftime (Python 3.14 compatibility)

### DIFF
--- a/custom_components/battery_notes/coordinator.py
+++ b/custom_components/battery_notes/coordinator.py
@@ -192,12 +192,12 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
 
                 if device_entry and device_entry.created_at.year > 1970:
                     last_replaced = device_entry.created_at.strftime(
-                        "%Y-%m-%dT%H:%M:%S:%f"
+                        "%Y-%m-%dT%H:%M:%S.%f"
                     )
             elif self.source_entity_id:
                 entity = entity_registry.async_get(self.source_entity_id)
                 if entity and entity.created_at.year > 1970:
-                    last_replaced = entity.created_at.strftime("%Y-%m-%dT%H:%M:%S:%f")
+                    last_replaced = entity.created_at.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
             _LOGGER.debug(
                 "Defaulting %s battery last replaced to %s",


### PR DESCRIPTION
Python 3.14 datetime.fromisoformat() became stricter and no longer accepts microsecond part with colon (:%f).
Changed to dot separator (.%f) to restore compatibility.

Solves following exception, that prevents Battery Notes to initialize:

ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Battery Notes for battery_notes
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.14/site-packages/homeassistant/config_entries.py", line 762, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ha/.homeassistant/custom_components/battery_notes/__init__.py", line 176, in async_setup_entry
    coordinator = BatteryNotesSubentryCoordinator(hass, config_entry, subentry)
  File "/home/ha/.homeassistant/custom_components/battery_notes/coordinator.py", line 209, in __init__
    self.last_replaced = datetime.fromisoformat(last_replaced)
                         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
ValueError: Invalid isoformat string: '2026-01-26T17:34:28:192804'
