### PR TITLE
Add Nedis SmartLife Smoke Detector Zigbee 3.0

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -38,6 +38,11 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "_TYZB01_ohyttvf6",
+            "model": "TS0205",
+            "battery_type": "CR123A"
+        },
+        {
             "manufacturer": "_TZ1800_ejwkn2h2",
             "model": "TY0203",
             "battery_type": "AAA",


### PR DESCRIPTION
Add Nedis SmartLife Smoke Detector Zigbee 3.0

Battery type CR123A as specified [here](https://nedis-shop.nl/en/collections/smart-home/products/smartlife-rookmelder-2)

<img width="332" height="390" alt="image" src="https://github.com/user-attachments/assets/048db90a-68be-45b8-ab4a-977841be6e77" />
