### PR TITLE
Remove model from b-parasite

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -2114,7 +2114,7 @@
         },
         {
             "manufacturer": "b-parasite",
-            "model": "Plant sensor",
+            "model": "b-parasite",
             "battery_type": "CR2032"
         },
         {


### PR DESCRIPTION
The b-parasite is an open hardware device and the default model is b-parasite [1]. Users may have customized that but we cannot account for that here.

    1: https://github.com/rbaron/b-parasite/blob/ff113c067778a1d80114cce58965b366f7854c0a/code/nrf-connect/samples/zigbee/Kconfig#L18