### PR TITLE
Add device: Bosch - Drive Unit Performance Line CX 

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -2175,6 +2175,11 @@
             "battery_type": "CR123"
         },
         {
+            "manufacturer": "Bosch",
+            "model": "Drive Unit Performance Line CX",
+            "battery_type": "Rechargeable"
+        },
+        {
             "manufacturer": "BOSCH",
             "model": "DWCII",
             "model_id": "12309",


### PR DESCRIPTION
Add device: Bosch e-bike Drive Unit "Drive Unit Performance Line CX" as reported by the "Bosch eBike Flow" integration