### PR TITLE
Add tado ST01 (Smart Thermostat) to device library

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -9111,6 +9111,12 @@
             "battery_quantity": 2
         },
         {
+            "manufacturer": "tado",
+            "model": "ST01",
+            "battery_type": "AAA",
+            "battery_quantity": 3
+        },
+        {
             "manufacturer": "Tado",
             "model": "SU02",
             "battery_type": "AAA",


### PR DESCRIPTION
Battery type: 3x AAA