### PR TITLE
Added generic Tuya Smart Scene Button

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -171,6 +171,11 @@
             "battery_type": "A23"
         },
         {
+            "manufacturer": "_TZ3000_abrsvsou",
+            "model": "TS004F",
+            "battery_type": "CR2032"
+        },
+        {
             "manufacturer": "_TZ3000_au1rjicn",
             "model": "TS0203",
             "battery_type": "CR2032"


### PR DESCRIPTION
Added a generic Tuya Smart Scene Button (Rotary scene switch button), as detected by ZHA.

Similar entries with slightly different manufacturers already exist in the library.

manufacturer: "_TZ3000_abrsvsou"
model: "TS004F"
