### PR TITLE
Fix naive datetime crash on HA 2026.4+ (last_replaced/last_reported)

### DIFF
--- a/custom_components/battery_notes/coordinator.py
+++ b/custom_components/battery_notes/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import cast
 
 from homeassistant.components.binary_sensor import (
@@ -69,6 +69,13 @@ from .filters import LowOutlierFilter
 from .store import BatteryNotesStorage
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_utc(dt_val: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware (UTC). Fixes naive datetimes from old storage."""
+    if dt_val.tzinfo is None:
+        return dt_val.replace(tzinfo=timezone.utc)
+    return dt_val
 
 
 @dataclass
@@ -683,7 +690,8 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
             )
 
         if entry and LAST_REPLACED in entry and entry[LAST_REPLACED] is not None:
-            return datetime.fromisoformat(str(entry[LAST_REPLACED]))
+            dt_val = datetime.fromisoformat(str(entry[LAST_REPLACED]))
+            return _ensure_utc(dt_val)
         return None
 
     @last_replaced.setter
@@ -692,7 +700,7 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
         if not hasattr(self.config_entry, "runtime_data"):
             return
 
-        entry = {LAST_REPLACED: value}
+        entry = {LAST_REPLACED: _ensure_utc(value) if isinstance(value, datetime) else value}
 
         if self.source_entity_id:
             self.async_update_entity_config(entity_id=self.source_entity_id, data=entry)
@@ -716,7 +724,8 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
             )
 
         if entry and LAST_REPORTED in entry and entry[LAST_REPORTED] is not None:
-            return datetime.fromisoformat(str(entry[LAST_REPORTED]))
+            dt_val = datetime.fromisoformat(str(entry[LAST_REPORTED]))
+            return _ensure_utc(dt_val)
 
         return None
 
@@ -727,7 +736,7 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
         if not hasattr(self.config_entry, "runtime_data"):
             return
 
-        entry = {LAST_REPORTED: value}
+        entry = {LAST_REPORTED: _ensure_utc(value) if isinstance(value, datetime) else value}
 
         if self.source_entity_id:
             self.async_update_entity_config(entity_id=self.source_entity_id, data=entry)

--- a/custom_components/battery_notes/coordinator.py
+++ b/custom_components/battery_notes/coordinator.py
@@ -700,7 +700,9 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
         if not hasattr(self.config_entry, "runtime_data"):
             return
 
-        entry = {LAST_REPLACED: _ensure_utc(value) if isinstance(value, datetime) else value}
+        entry = {
+            LAST_REPLACED: _ensure_utc(value) if isinstance(value, datetime) else value
+        }
 
         if self.source_entity_id:
             self.async_update_entity_config(entity_id=self.source_entity_id, data=entry)
@@ -736,7 +738,9 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
         if not hasattr(self.config_entry, "runtime_data"):
             return
 
-        entry = {LAST_REPORTED: _ensure_utc(value) if isinstance(value, datetime) else value}
+        entry = {
+            LAST_REPORTED: _ensure_utc(value) if isinstance(value, datetime) else value
+        }
 
         if self.source_entity_id:
             self.async_update_entity_config(entity_id=self.source_entity_id, data=entry)

--- a/custom_components/battery_notes/coordinator.py
+++ b/custom_components/battery_notes/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import cast
 
 from homeassistant.components.binary_sensor import (
@@ -74,7 +74,7 @@ _LOGGER = logging.getLogger(__name__)
 def _ensure_utc(dt_val: datetime) -> datetime:
     """Ensure a datetime is timezone-aware (UTC). Fixes naive datetimes from old storage."""
     if dt_val.tzinfo is None:
-        return dt_val.replace(tzinfo=timezone.utc)
+        return dt_val.replace(tzinfo=datetime.UTC)
     return dt_val
 
 

--- a/custom_components/battery_notes/coordinator.py
+++ b/custom_components/battery_notes/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from homeassistant.components.binary_sensor import (
@@ -74,7 +74,7 @@ _LOGGER = logging.getLogger(__name__)
 def _ensure_utc(dt_val: datetime) -> datetime:
     """Ensure a datetime is timezone-aware (UTC). Fixes naive datetimes from old storage."""
     if dt_val.tzinfo is None:
-        return dt_val.replace(tzinfo=datetime.UTC)
+        return dt_val.replace(tzinfo=UTC)
     return dt_val
 
 


### PR DESCRIPTION
## What

Ensures all datetimes returned by `last_replaced` and `last_reported` are
timezone-aware (UTC). Fixes crash on HA Core 2026.4+ which now strictly
enforces timezone-aware datetimes for `SensorDeviceClass.TIMESTAMP` sensors.

## Why

After updating to HA Core 2026.4, all `sensor.*_battery_last_replaced` entities
crash with `ValueError: missing timezone information`. This happens even on
clean installs because `device_entry.created_at` defaults are stored as naive
datetimes.

Fixes follow-up to #4595 which only addressed the `set_battery_replaced` action.

## How

- Added `_ensure_utc()` helper: converts naive datetimes to UTC, passes through
  already-aware datetimes unchanged
- Applied 