### PR TITLE
Add device: Aqara Multi-State Sensor P100

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -1292,7 +1292,7 @@
         },
         {
             "manufacturer": "Aqara",
-            "model": "Aqara Multi-State Sensor P100",
+            "model": "Multi-State Sensor P100",
             "model_id": "DWZTCGQ11LM",
             "hw_version": "1",
             "battery_type": "CR2450"

--- a/library/library.json
+++ b/library/library.json
@@ -1292,6 +1292,13 @@
         },
         {
             "manufacturer": "Aqara",
+            "model": "Aqara Multi-State Sensor P100",
+            "model_id": "DWZTCGQ11LM",
+            "hw_version": "1",
+            "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "Aqara",
             "model": "Aqara Smart Lock U100",
             "battery_type": "AA",
             "battery_quantity": 4


### PR DESCRIPTION
        {
            "manufacturer": "Aqara",
            "model": "Multi-State Sensor P100",
            "model_id": "DWZTCGQ11LM",
            "hw_version": "1",
            "battery_type": "CR2450"
        },