### PR TITLE
Add Hatch, Yoto and CyberPower OR1500 devices

### DIFF
--- a/library/library.json
+++ b/library/library.json
@@ -2661,6 +2661,11 @@
             "battery_type": "RB1290X2"
         },
         {
+            "manufacturer": "CPS",
+            "model": "OR1500LCDRM1Ua",
+            "battery_type": "RB0690X4"
+        },
+        {
             "manufacturer": "Custom devices (DiY)",
             "model": "Plant watering sensor zFlora_S (zFlora_S)",
             "battery_type": "CR2450"
@@ -4861,6 +4866,16 @@
             "manufacturer": "HARMAN International Industries",
             "model": "JBL BAR 1000",
             "hw_version": "MT8518",
+            "battery_type": "Rechargeable"
+        },
+        {
+            "manufacturer": "Hatch",
+            "model": "RestIot",
+            "battery_type": "Rechargeable"
+        },
+        {
+            "manufacturer": "Hatch",
+            "model": "RestPlus",
             "battery_type": "Rechargeable"
         },
         {
@@ -12967,6 +12982,16 @@
             "manufacturer": "Yookee",
             "model": "Smart blind",
             "model_id": "D10110_1",
+            "battery_type": "Rechargeable"
+        },
+        {
+            "manufacturer": "Yoto",
+            "model": "Yoto Mini",
+            "battery_type": "Rechargeable"
+        },
+        {
+            "manufacturer": "Yoto",
+            "model": "Yoto Player",
             "battery_type": "Rechargeable"
         },
         {


### PR DESCRIPTION
Adds five devices to `library/library.json`, verified from the Home Assistant device screens:

| Manufacturer | Model | Battery Type |
|---|---|---|
| Hatch | RestIot | Rechargeable |
| Hatch | RestPlus | Rechargeable |
| Yoto | Yoto Mini | Rechargeable |
| Yoto | Yoto Player | Rechargeable |
| CPS | OR1500LCDRM1Ua | RB0690X4 |

- Hatch and Yoto units have bespoke built-in rechargeable batteries → `Rechargeable`.
- The CyberPower OR1500LCDRM1Ua replacement cartridge is `RB0690X4` (6V 9Ah ×4), consistent with the existing `CPS` entries.
- Entries inserted in alphabetical position; no `battery_quantity` needed (single pack each).
- GitHub Actions left disabled on the fork per the contributing docs.