### PR TITLE
Fix binary low sensor

### DIFF
--- a/custom_components/battery_notes/binary_sensor.py
+++ b/custom_components/battery_notes/binary_sensor.py
@@ -586,13 +586,15 @@ class BatteryNotesBatteryWrappedLowSensor(BatteryNotesNonTemplateBatteryLowSenso
         self.async_write_ha_state()
 
         _LOGGER.debug(
-            "%s binary sensor battery_low set to: %s",
+            "%s binary sensor battery_low set to: %s via wrapped low sensor",
             self.coordinator.wrapped_battery.entity_id,
             self.coordinator.battery_low,
         )
 
 
-class BatteryNotesBatteryBinaryLowSensor(BatteryNotesNonTemplateBatteryLowSensor):
+class BatteryNotesBatteryBinaryLowSensor(
+    BatteryNotesNonTemplateBatteryLowSensor, RestoreEntity
+):
     """Represents a low battery binary sensor from a binary sensor."""
 
     _attr_should_poll = False
@@ -815,7 +817,7 @@ class BatteryNotesBatteryBinaryLowSensor(BatteryNotesNonTemplateBatteryLowSensor
         self.async_write_ha_state()
 
         _LOGGER.debug(
-            "%s binary sensor battery_low set to: %s",
+            "%s binary sensor battery_low set to: %s via binary low sensor",
             self.coordinator.wrapped_battery_low.entity_id,
             self.coordinator.battery_low,
         )

--- a/custom_components/battery_notes/binary_sensor.py
+++ b/custom_components/battery_notes/binary_sensor.py
@@ -295,6 +295,7 @@ class BatteryNotesNonTemplateBatteryLowSensor(BatteryNotesBatteryLowBaseSensor):
                 self.entity_id,
                 hidden_by=er.RegistryEntryHider.INTEGRATION
                 if self.hass.data[MY_KEY].hide_battery_low
+                and self.coordinator.wrapped_battery is not None
                 else None,
             )
 
@@ -592,9 +593,7 @@ class BatteryNotesBatteryWrappedLowSensor(BatteryNotesNonTemplateBatteryLowSenso
         )
 
 
-class BatteryNotesBatteryBinaryLowSensor(
-    BatteryNotesNonTemplateBatteryLowSensor, RestoreEntity
-):
+class BatteryNotesBatteryBinaryLowSensor(BatteryNotesNonTemplateBatteryLowSensor):
     """Represents a low battery binary sensor from a binary sensor."""
 
     _attr_should_poll = False
@@ -722,6 +721,8 @@ class BatteryNotesBatteryBinaryLowSensor(
 
     async def async_added_to_hass(self) -> None:
         """Handle added to Hass."""
+
+        await super().async_added_to_hass()
 
         @callback
         async def _async_state_changed_listener(

--- a/custom_components/battery_notes/coordinator.py
+++ b/custom_components/battery_notes/coordinator.py
@@ -314,6 +314,8 @@ class BatteryNotesSubentryCoordinator(DataUpdateCoordinator[None]):
                     device_class,
                     entity.unit_of_measurement,
                 )
+            if device_class == BinarySensorDeviceClass.BATTERY:
+                self.wrapped_battery_low = entity
 
             self.device_name = self.subentry.title
         else:


### PR DESCRIPTION
Devices with just a binary battery sensor now correctly set state at add or restart.
Entity type battery notes now create a battery_plus_low sensor.