### PR TITLE
fix: compare battery_low_binary_state as the bool it is, not a string

### DIFF
--- a/custom_components/battery_notes/binary_sensor.py
+++ b/custom_components/battery_notes/binary_sensor.py
@@ -813,7 +813,7 @@ class BatteryNotesBatteryBinaryLowSensor(BatteryNotesNonTemplateBatteryLowSensor
             self.async_write_ha_state()
             return
 
-        self._attr_is_on = self.coordinator.battery_low_binary_state == "on"
+        self._attr_is_on = self.coordinator.battery_low_binary_state
 
         self.async_write_ha_state()
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,86 @@
+"""Tests for BatteryNotesBatteryBinaryLowSensor's coordinator-refresh handling.
+
+`battery_low_binary_state` is a bool (see `async_state_changed_listener`,
+which assigns it `wrapped_battery_low_state.state == "on"` once). Comparing
+it against the string "on" again in `_handle_coordinator_update` is always
+False, which is why a coordinator refresh (e.g. HA startup/reload) always
+reset the exposed entity to "off" regardless of the real source state --
+only a live state-change event (which sets `_attr_is_on` directly from the
+bool) ever showed the correct value. See issue #5078.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from custom_components.battery_notes.binary_sensor import (
+    BatteryNotesBatteryBinaryLowSensor,
+)
+
+from homeassistant.const import STATE_UNAVAILABLE
+
+
+def _sensor(
+    *, battery_low_binary_state: bool, wrapped_state: str
+) -> BatteryNotesBatteryBinaryLowSensor:
+    """Build a BatteryNotesBatteryBinaryLowSensor with just enough wiring for _handle_coordinator_update."""
+    sensor = BatteryNotesBatteryBinaryLowSensor.__new__(
+        BatteryNotesBatteryBinaryLowSensor
+    )
+
+    sensor.coordinator = MagicMock()
+    sensor.coordinator.wrapped_battery_low = MagicMock(
+        entity_id="binary_sensor.source_battery"
+    )
+    sensor.coordinator.battery_low_binary_state = battery_low_binary_state
+
+    sensor.hass = MagicMock()
+    sensor.hass.states.get.return_value = MagicMock(state=wrapped_state)
+
+    sensor.async_write_ha_state = MagicMock()
+
+    return sensor
+
+
+@pytest.mark.parametrize(
+    ("battery_low_binary_state", "expected_is_on"),
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_handle_coordinator_update_reflects_stored_bool(
+    battery_low_binary_state: bool, expected_is_on: bool
+) -> None:
+    """A coordinator refresh must expose the stored bool as-is."""
+    sensor = _sensor(
+        battery_low_binary_state=battery_low_binary_state, wrapped_state="on"
+    )
+
+    sensor._handle_coordinator_update()  # noqa: SLF001
+
+    assert sensor._attr_is_on is expected_is_on  # noqa: SLF001
+
+
+def test_handle_coordinator_update_matches_state_changed_listener() -> None:
+    """The two update paths must agree.
+
+    A source already 'on' at coordinator refresh time (e.g. HA startup)
+    must expose the same state a live state-change event would have set.
+    """
+    sensor = _sensor(battery_low_binary_state=True, wrapped_state="on")
+
+    sensor._handle_coordinator_update()  # noqa: SLF001
+
+    assert sensor._attr_is_on is True  # noqa: SLF001
+
+
+def test_handle_coordinator_update_unavailable_source() -> None:
+    """An unavailable/unknown source clears the state, regardless of the stored bool."""
+    sensor = _sensor(battery_low_binary_state=True, wrapped_state=STATE_UNAVAILABLE)
+
+    sensor._handle_coordinator_update()  # noqa: SLF001
+
+    assert sensor._attr_is_on is None  # noqa: SLF001
+    assert sensor._attr_available is False  # noqa: SLF001


### PR DESCRIPTION
## Problem

`BatteryNotesBatteryBinaryLowSensor._handle_coordinator_update()`:

```python
self._attr_is_on = self.coordinator.battery_low_binary_state == "on"
```

`battery_low_binary_state` is a **bool** — set in `async_state_changed_listener` as `wrapped_battery_low_state.state == "on"`. Comparing it against the string `"on"` again is always `False`, regardless of the actual value. So every coordinator refresh (HA startup, integration reload, `async_refresh()`) resets the exposed entity to "off" no matter what the source sensor says.

The sibling code path, `async_state_changed_listener` (fires on a live state-change event, e.g. toggling the source sensor in Developer Tools), does it correctly a few lines above:

```python
self._attr_is_on = self.coordinator.battery_low_binary_state
```

This fully explains #5078's reported symptom and reproduction steps: correct after a manual toggle, wrong after add/restart/reload.

## Relation to #5080

#5080 (merged just before I opened this) fixed a related-but-different bug in the same area: `wrapped_battery_low` wasn't being wired up on the coordinator for this sensor type, and `async_added_to_hass()` wasn't calling `super()`. That's likely why some configurations stopped showing the symptom after #5080 — but it didn't touch this comparison, which is still present and still wrong on `main`. With #5080's coordinator change now reliably setting `wrapped_battery_low`, `_handle_coordinator_update` reaches this line on every refresh going forward, so it's worth fixing directly rather than relying on the earlier guard rarely being hit.

## Fix

Assign the bool directly, mirroring `async_state_changed_listener`'s already-correct pattern.

## Testing

Added `tests/test_binary_sensor.py` (4 tests, constructing the sensor via `__new__` with a mock coordinator/hass since this needs no more than `_handle_coordinator_update` touches):
- reflects the stored bool for both `True`/`False`
- matches what `async_state_changed_listener` would have set for the same underlying state
- unavailable/unknown source still correctly clears state regardless of the stored bool

Confirmed the two `True`-expecting tests fail against the pre-fix line (`git stash` on just `binary_sensor.py`) with the exact reported symptom (`False` instead of `True`), and pass with the fix. Full suite: 14/14 (10 pre-existing + 4 new). `ruff check`, `ruff format --check`, `mypy --check-untyped-defs`: all clean.